### PR TITLE
Add vidinfo.py

### DIFF
--- a/video/vidinfo.py
+++ b/video/vidinfo.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# vidinfo.py,v1.0.0
+
+# Copyright (c) 2021 Thomas Ward <thomas@thomasward.com>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Outputs a csv with information on the container and video bitstream
+formats (codecs) of videos in the specified directory. Requires ffprobe
+installed.
+"""
+
+import argparse
+import os
+from shutil import which
+import subprocess
+import sys
+
+def parser():
+    """Returns an argparse parser."""
+    parser = argparse.ArgumentParser(
+        description="Collect video format/codec information.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-t",
+        "--toplevel",
+        action="store_true",
+        default=False,
+        help="Only analyze videos in directory, not its subdirectories.",
+    )
+    parser.add_argument(
+        "-o", "--output", help="CSV output filename", default="vidinfo.csv"
+    )
+    parser.add_argument("directory", help="directory with videos")
+    return parser
+
+
+def valid_args(args):
+    """Validates args."""
+    if not os.path.isdir(args.directory):
+        print(f"{args.directory} is not a directory. Exiting.", file=sys.stderr)
+        return False
+    if os.path.exists(args.output):
+        print(f"{args.output} already exists. Exiting.", file=sys.stderr)
+        return False
+    return True
+
+
+def main():
+    args = parser().parse_args("asdf".split())
+    if not valid_args(args):
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    if which("ffprobe"):
+        main()
+    print("ffprobe not found", file=sys.stderr)
+    sys.exit(2)

--- a/video/vidinfo.py
+++ b/video/vidinfo.py
@@ -28,6 +28,7 @@ from shutil import which
 import subprocess
 import sys
 
+
 def parser():
     """Returns an argparse parser."""
     parser = argparse.ArgumentParser(
@@ -59,10 +60,25 @@ def valid_args(args):
     return True
 
 
+def all_files(directory):
+    """Returns all files in directory, recursing through subdirectories."""
+    return (os.path.join(dirp, f) for dirp, _, fs in os.walk(directory) for f in fs)
+
+
+def toplevel_files(directory):
+    """Returns all toplevel files in directory."""
+    with os.scandir(directory) as it:
+        for entry in it:
+            if entry.is_file():
+                yield entry.path
+
+
 def main():
-    args = parser().parse_args("asdf".split())
+
+    args = parser().parse_args("/home/thomas/noBackup".split())
     if not valid_args(args):
         sys.exit(2)
+    files_within = toplevel_files if args.toplevel else all_files
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Little python script that leverages `ffprobe` to report the following information for videos location in a directory:

1. Filename
2. Video stream number (0-indexed. Most videos only have one video stream.)
3. Video codec name (standard name reported by ffmpeg/ffprobe)
4. Width (pixels)
5. Height (pixels)
6. Video container format (standard name reported by ffmpeg/ffprobe)
7. Duration (seconds)

It will report one item per video stream in the video file. Most videos only have one stream.